### PR TITLE
Adding logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,4 +157,4 @@ target_link_libraries(SimpleTaskManager protobuf::libprotobuf gRPC::grpc++ gRPC:
 target_link_libraries(server protobuf::libprotobuf gRPC::grpc++ gRPC::grpc++_reflection ${Boost_LIBRARIES})
 target_link_libraries(client protobuf::libprotobuf gRPC::grpc++ gRPC::grpc++_reflection ${Boost_LIBRARIES})
 
-target_link_libraries(SimpleTaskManager_test protobuf::libprotobuf gRPC::grpc++ gRPC::grpc++_reflection GTest::gtest GTest::gmock GTest::gmock_main ${Boost_LIBRARIES})
+target_link_libraries(SimpleTaskManager_test protobuf::libprotobuf gRPC::grpc++ gRPC::grpc++_reflection GTest::gtest GTest::gmock ${Boost_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(Boost_USE_RELEASE_LIBS       ON)  # only find release libs
 set(Boost_USE_MULTITHREADED      ON)
 set(Boost_USE_STATIC_RUNTIME    OFF)
 
-find_package(Boost REQUIRED log COMPONENTS)
+find_package(Boost REQUIRED log_setup log COMPONENTS)
 if(Boost_FOUND)
     message(STATUS "Using BOOST ${Boost_VERSION}")
     include_directories(${Boost_INCLUDE_DIRS})
@@ -41,7 +41,9 @@ file(GLOB_RECURSE TaskManager_SRCS CONFIGURE_DEPENDS
         "src/utilities/*.h"
         "src/utilities/*.cpp"
         "src/persistence/*.h"
-        "src/persistence/*.cpp")
+        "src/persistence/*.cpp"
+        "src/logs/*.h"
+        "src/logs/*.cpp")
 
 file(GLOB_RECURSE SERVER_SRCS CONFIGURE_DEPENDS
         "src/model/*.h"
@@ -49,7 +51,9 @@ file(GLOB_RECURSE SERVER_SRCS CONFIGURE_DEPENDS
         "src/utilities/*.h"
         "src/utilities/*.cpp"
         "src/server/*.h"
-        "src/server/*.cpp")
+        "src/server/*.cpp"
+        "src/logs/*.h"
+        "src/logs/*.cpp")
 
 file(GLOB_RECURSE CLIENT_SRCS CONFIGURE_DEPENDS
         "src/view/*.h"
@@ -62,7 +66,9 @@ file(GLOB_RECURSE CLIENT_SRCS CONFIGURE_DEPENDS
         "src/controller/*.cpp"
         "src/persistence/*.h"
         "src/persistence/*.cpp"
-        "src/model/Model.h")
+        "src/model/Model.h"
+        "src/logs/*.h"
+        "src/logs/*.cpp")
 
 file(GLOB_RECURSE TaskManager_TEST CONFIGURE_DEPENDS
         "tests/*.h"

--- a/src/client/GRPCClientEndPoint.cpp
+++ b/src/client/GRPCClientEndPoint.cpp
@@ -23,7 +23,10 @@ std::pair<TaskActionResult, TaskId> GRPCClientEndPoint::AddTask(const Task& task
 
     grpc::Status status = stub_->AddTask(&context, request, &response);
 
-    LOG_TRIVIAL(debug) << "Request success: " << status.ok() << ", " << response.added_task_id().ShortDebugString();
+    if (!status.ok())
+        LOG_TRIVIAL(error) << status.error_message();
+    else
+        LOG_TRIVIAL(debug) << "Request answer: " << response.added_task_id().ShortDebugString();
 
     return std::make_pair(CreateTaskActionResult(response.result()), response.added_task_id());
 }
@@ -40,7 +43,10 @@ std::pair<TaskActionResult, TaskId> GRPCClientEndPoint::AddSubTask(const Task& t
 
     grpc::Status status = stub_->AddSubTask(&context, request, &response);
 
-    LOG_TRIVIAL(debug) << "Request success: " << status.ok() << ", " << response.added_task_id().ShortDebugString();
+    if (!status.ok())
+        LOG_TRIVIAL(error) << status.error_message();
+    else
+        LOG_TRIVIAL(debug) << "Request answer: " << response.added_task_id().ShortDebugString();
 
     return std::make_pair(CreateTaskActionResult(response.result()), response.added_task_id());
 }
@@ -120,7 +126,10 @@ std::vector<RelationalTask> GRPCClientEndPoint::GetTasks() {
 
     grpc::Status status = stub_->GetTasks(&context, request, &response);
 
-    LOG_TRIVIAL(debug) << "Tasks received: " << response.tasks_size();
+    if (!status.ok())
+        LOG_TRIVIAL(error) << status.error_message();
+    else
+        LOG_TRIVIAL(debug) << "Tasks received: " << response.tasks_size();
 
     std::vector<RelationalTask> tasks;
     for (const auto& task : response.tasks()) {

--- a/src/client/GRPCClientEndPoint.cpp
+++ b/src/client/GRPCClientEndPoint.cpp
@@ -7,6 +7,8 @@
 #include "Requests.pb.h"
 #include "Responses.pb.h"
 
+#include "logs/DefaultLogging.h"
+
 GRPCClientEndPoint::GRPCClientEndPoint(std::unique_ptr<TaskManagerService::StubInterface> stub) :
         stub_(std::move(stub)) {}
 
@@ -17,7 +19,11 @@ std::pair<TaskActionResult, TaskId> GRPCClientEndPoint::AddTask(const Task& task
     AddTaskResponse response;
     grpc::ClientContext context;
 
+    LOG_TRIVIAL(debug) << "Sending request, Task: {" << task.ShortDebugString() << "}";
+
     grpc::Status status = stub_->AddTask(&context, request, &response);
+
+    LOG_TRIVIAL(debug) << "Request success: " << status.ok() << ", " << response.added_task_id().ShortDebugString();
 
     return std::make_pair(CreateTaskActionResult(response.result()), response.added_task_id());
 }
@@ -30,7 +36,11 @@ std::pair<TaskActionResult, TaskId> GRPCClientEndPoint::AddSubTask(const Task& t
     AddSubTaskResponse response;
     grpc::ClientContext context;
 
+    LOG_TRIVIAL(debug) << "Sending request, Task: {" << task.ShortDebugString() << "}, " << parent_id.ShortDebugString();
+
     grpc::Status status = stub_->AddSubTask(&context, request, &response);
+
+    LOG_TRIVIAL(debug) << "Request success: " << status.ok() << ", " << response.added_task_id().ShortDebugString();
 
     return std::make_pair(CreateTaskActionResult(response.result()), response.added_task_id());
 }
@@ -106,7 +116,11 @@ std::vector<RelationalTask> GRPCClientEndPoint::GetTasks() {
     GetTasksResponse response;
     grpc::ClientContext context;
 
+    LOG_TRIVIAL(debug) << "Sending request";
+
     grpc::Status status = stub_->GetTasks(&context, request, &response);
+
+    LOG_TRIVIAL(debug) << "Tasks received: " << response.tasks_size();
 
     std::vector<RelationalTask> tasks;
     for (const auto& task : response.tasks()) {

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -13,11 +13,15 @@
 #include "client/GRPCClientEndPoint.h"
 #include "controller/DefaultModelController.h"
 
+#include "logs/LogInit.h"
+
 #include <grpcpp/grpcpp.h>
 
 #include <string>
 
 int main() {
+    logs_init();
+
     std::string target_str = "localhost:8586";
 
     std::shared_ptr<CommandFactory> command_factory = std::make_shared<CommandFactory>();

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -20,7 +20,7 @@
 #include <string>
 
 int main() {
-    logs_init();
+    logs_init(false);
 
     std::string target_str = "localhost:8586";
 

--- a/src/logs/DefaultLogging.h
+++ b/src/logs/DefaultLogging.h
@@ -1,0 +1,17 @@
+//
+// Created by Maksym Kharchenko on 02.02.2022.
+//
+
+#ifndef SIMPLETASKMANAGER_DEFAULTLOGGING_H
+#define SIMPLETASKMANAGER_DEFAULTLOGGING_H
+
+#include <boost/log/trivial.hpp>
+#include <boost/log/expressions/formatters/named_scope.hpp>
+#include <boost/log/utility/manipulators/add_value.hpp>
+
+#define LOG_TRIVIAL(LEVEL) \
+    BOOST_LOG_TRIVIAL(LEVEL)   \
+        << boost::log::add_value("File", __FILE_NAME__) \
+        << boost::log::add_value("Function", __FUNCTION__)
+
+#endif //SIMPLETASKMANAGER_DEFAULTLOGGING_H

--- a/src/logs/LogInit.cpp
+++ b/src/logs/LogInit.cpp
@@ -17,24 +17,35 @@
 #include <iostream>
 
 void logs_init() {
+    //boost::log::core::get()->add_global_attribute("Scope", boost::log::attributes::named_scope());
+
+    /*auto log_format = boost::log::expressions::stream
+            << "[" << boost::log::expressions::format_date_time< boost::posix_time::ptime >("TimeStamp", "%Y-%m-%d %H:%M:%S")
+            << "] [" << boost::log::expressions::format_named_scope(
+            "Scope",
+            boost::log::keywords::format = "%n",
+            boost::log::keywords::incomplete_marker = "",
+            boost::log::keywords::depth = 2)
+            << "] <" << boost::log::trivial::severity
+            << ">: " << boost::log::expressions::smessage;*/
+
+    auto log_format = boost::log::expressions::stream
+            << "[" << boost::log::expressions::format_date_time< boost::posix_time::ptime >("TimeStamp", "%Y-%m-%d %H:%M:%S")
+            << "] [" << boost::log::expressions::attr<std::string>("File")
+            << ":" << boost::log::expressions::attr<std::string>("Function")
+            << "] <" << boost::log::trivial::severity
+            << ">: " << boost::log::expressions::smessage;
+
     boost::log::add_file_log(
             boost::log::keywords::file_name = "task_manager_%N.log",
             boost::log::keywords::rotation_size = 5 * 1024 * 1024,
             boost::log::keywords::auto_flush = true,
             boost::log::keywords::open_mode = std::ios_base::app,
-            boost::log::keywords::format = (
-                            boost::log::expressions::stream
-                            << boost::log::expressions::format_date_time< boost::posix_time::ptime >("TimeStamp", "%Y-%m-%d %H:%M:%S")
-                            << ": <" << boost::log::trivial::severity
-                            << "> " << boost::log::expressions::message));
+            boost::log::keywords::format = log_format);
 
     boost::log::add_console_log(
             std::cout,
-            boost::log::keywords::format = (
-                    boost::log::expressions::stream
-                            << boost::log::expressions::format_date_time< boost::posix_time::ptime >("TimeStamp", "%Y-%m-%d %H:%M:%S")
-                            << ": <" << boost::log::trivial::severity
-                            << "> " << boost::log::expressions::message));
+            boost::log::keywords::format = log_format);
 
     boost::log::add_common_attributes();
 }

--- a/src/logs/LogInit.cpp
+++ b/src/logs/LogInit.cpp
@@ -1,0 +1,40 @@
+//
+// Created by Maksym Kharchenko on 01.02.2022.
+//
+
+#include "LogInit.h"
+
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/log/expressions.hpp>
+#include <boost/log/sources/severity_logger.hpp>
+#include <boost/log/sources/record_ostream.hpp>
+#include <boost/log/utility/setup/file.hpp>
+#include <boost/log/utility/setup/console.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
+#include <boost/log/support/date_time.hpp>
+
+#include <iostream>
+
+void logs_init() {
+    boost::log::add_file_log(
+            boost::log::keywords::file_name = "task_manager_%N.log",
+            boost::log::keywords::rotation_size = 5 * 1024 * 1024,
+            boost::log::keywords::auto_flush = true,
+            boost::log::keywords::open_mode = std::ios_base::app,
+            boost::log::keywords::format = (
+                            boost::log::expressions::stream
+                            << boost::log::expressions::format_date_time< boost::posix_time::ptime >("TimeStamp", "%Y-%m-%d %H:%M:%S")
+                            << ": <" << boost::log::trivial::severity
+                            << "> " << boost::log::expressions::message));
+
+    boost::log::add_console_log(
+            std::cout,
+            boost::log::keywords::format = (
+                    boost::log::expressions::stream
+                            << boost::log::expressions::format_date_time< boost::posix_time::ptime >("TimeStamp", "%Y-%m-%d %H:%M:%S")
+                            << ": <" << boost::log::trivial::severity
+                            << "> " << boost::log::expressions::message));
+
+    boost::log::add_common_attributes();
+}

--- a/src/logs/LogInit.cpp
+++ b/src/logs/LogInit.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-void logs_init() {
+void logs_init(const bool show_in_console) {
     //boost::log::core::get()->add_global_attribute("Scope", boost::log::attributes::named_scope());
 
     /*auto log_format = boost::log::expressions::stream
@@ -43,9 +43,11 @@ void logs_init() {
             boost::log::keywords::open_mode = std::ios_base::app,
             boost::log::keywords::format = log_format);
 
-    boost::log::add_console_log(
-            std::cout,
-            boost::log::keywords::format = log_format);
+    if (show_in_console) {
+        boost::log::add_console_log(
+                std::cout,
+                boost::log::keywords::format = log_format);
+    }
 
     boost::log::add_common_attributes();
 }

--- a/src/logs/LogInit.h
+++ b/src/logs/LogInit.h
@@ -1,0 +1,10 @@
+//
+// Created by Maksym Kharchenko on 01.02.2022.
+//
+
+#ifndef SIMPLETASKMANAGER_LOGINIT_H
+#define SIMPLETASKMANAGER_LOGINIT_H
+
+void logs_init();
+
+#endif //SIMPLETASKMANAGER_LOGINIT_H

--- a/src/logs/LogInit.h
+++ b/src/logs/LogInit.h
@@ -5,6 +5,6 @@
 #ifndef SIMPLETASKMANAGER_LOGINIT_H
 #define SIMPLETASKMANAGER_LOGINIT_H
 
-void logs_init();
+void logs_init(bool show_in_console = true);
 
 #endif //SIMPLETASKMANAGER_LOGINIT_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,9 +8,13 @@
 #include "ViewController.h"
 #include "persistence/PersistenceFactory.h"
 
+#include "logs/LogInit.h"
+
 #include <memory>
 
 int main() {
+    logs_init();
+
     std::shared_ptr<CommandFactory> command_factory = std::make_shared<CommandFactory>();
     std::shared_ptr<ConsolePrinter> printer = std::make_shared<ConsolePrinter>();
     std::shared_ptr<ConsoleReader> reader = std::make_shared<ConsoleReader>();

--- a/src/model/TaskManager.cpp
+++ b/src/model/TaskManager.cpp
@@ -25,7 +25,7 @@ TaskManager::TaskManager(std::unique_ptr<IdGenerator> generator,
 
 std::pair<TaskActionResult, TaskId> TaskManager::AddTask(const Task& task) {
     if (!task_validator_->ValidateTask(task)) {
-        LOG_TRIVIAL(warning) << "Invalid task given, Task: " << task.ShortDebugString();
+        LOG_TRIVIAL(error) << "Invalid task given, Task: " << task.ShortDebugString();
         return std::pair(TaskActionResult::FAIL_INVALID_TASK, TaskId::default_instance());
     }
 
@@ -39,7 +39,7 @@ std::pair<TaskActionResult, TaskId> TaskManager::AddTask(const Task& task) {
 
 std::pair<TaskActionResult, TaskId> TaskManager::AddSubTask(const Task& task, const TaskId& parent_id) {
     if (!task_validator_->ValidateTask(task)) {
-        LOG_TRIVIAL(warning) << "Invalid task given, Task: " << task.ShortDebugString();
+        LOG_TRIVIAL(error) << "Invalid task given, Task: " << task.ShortDebugString();
         return std::pair(TaskActionResult::FAIL_INVALID_TASK, TaskId::default_instance());
     }
 
@@ -124,6 +124,9 @@ std::vector<RelationalTask> TaskManager::GetTasks() {
             tasks.insert(tasks.end(), adding_tasks.begin(), adding_tasks.end());
         }
     }
+
+    LOG_TRIVIAL(debug) << "Tasks returned: " << tasks.size();
+
     return tasks;
 }
 

--- a/src/model/TaskManager.cpp
+++ b/src/model/TaskManager.cpp
@@ -6,6 +6,8 @@
 #include "utilities/TaskComparators.h"
 #include "TaskNodeFactoryMethod.h"
 
+#include "logs/DefaultLogging.h"
+
 using namespace model;
 
 TaskManager::TaskManager(std::unique_ptr<IdGenerator> generator) :
@@ -23,26 +25,35 @@ TaskManager::TaskManager(std::unique_ptr<IdGenerator> generator,
 
 std::pair<TaskActionResult, TaskId> TaskManager::AddTask(const Task& task) {
     if (!task_validator_->ValidateTask(task)) {
+        LOG_TRIVIAL(warning) << "Invalid task given, Task: " << task.ShortDebugString();
         return std::pair(TaskActionResult::FAIL_INVALID_TASK, TaskId::default_instance());
     }
 
     TaskId task_id = generator_->CreateNewTaskId();
     tasks_.insert({ task_id, model::CreateTaskNode(task) });
+
+    LOG_TRIVIAL(debug) << "Task added, " << task_id.ShortDebugString();
+
     return std::pair(TaskActionResult::SUCCESS, task_id);
 }
 
 std::pair<TaskActionResult, TaskId> TaskManager::AddSubTask(const Task& task, const TaskId& parent_id) {
     if (!task_validator_->ValidateTask(task)) {
+        LOG_TRIVIAL(warning) << "Invalid task given, Task: " << task.ShortDebugString();
         return std::pair(TaskActionResult::FAIL_INVALID_TASK, TaskId::default_instance());
     }
 
     auto parent_task = tasks_.find(parent_id);
     if (parent_task == tasks_.end()) {
+        LOG_TRIVIAL(warning) << "No such task found, " << parent_id.ShortDebugString();
         return std::pair(TaskActionResult::FAIL_NO_SUCH_TASK, TaskId::default_instance());
     }
 
     TaskId subtask_id = generator_->CreateNewTaskId();
     tasks_.insert({ subtask_id, model::CreateTaskNode(task, parent_id) });
+
+    LOG_TRIVIAL(debug) << "Task added, " << subtask_id.ShortDebugString();
+
     return std::pair(TaskActionResult::SUCCESS, subtask_id);
 }
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -9,10 +9,14 @@
 #include "model/TaskManager.h"
 #include "model/IdGenerator.h"
 
+#include "logs/LogInit.h"
+
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
 
 int main() {
+    logs_init();
+
     std::unique_ptr<Model> model =
             std::make_unique<TaskManager>(std::make_unique<IdGenerator>());
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -2,14 +2,13 @@
 // Created by Maksym Kharchenko on 25.01.2022.
 //
 
-#include <boost/log/trivial.hpp>
-
 #include "server/GRPCServerEndPoint.h"
 
 #include "model/TaskManager.h"
 #include "model/IdGenerator.h"
 
 #include "logs/LogInit.h"
+#include "logs/DefaultLogging.h"
 
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
@@ -33,7 +32,10 @@ int main() {
     // Finally assemble the server.
     std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
     //std::cout << "Server listening on " << server_address << std::endl;
-    BOOST_LOG_TRIVIAL(info) << "Server listening on " << server_address;
+
+    //BOOST_LOG_NAMED_SCOPE(__FILE__);
+    //BOOST_LOG_NAMED_SCOPE(__FUNCTION__);
+    LOG_TRIVIAL(info) << "Server listening on " << server_address;
 
     // Wait for the server to shutdown. Note that some other thread must be
     // responsible for shutting down the server for this call to ever return.

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,14 @@
+//
+// Created by Maksym Kharchenko on 03.02.2022.
+//
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <boost/log/core.hpp>
+
+int main(int argc, char** argv) {
+    boost::log::core::get()->set_logging_enabled(false);
+    testing::InitGoogleMock(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Added logs in:

- `Client` end point on `AddTask`, `AddSubTask` and `GetTasks` methods.
- `Server` end point on `AddTask`, `AddSubTask` and `GetTasks` methods.
- `TaskManager` on `AddTask`, `AddSubTask` and `GetTasks` methods.
- `DefaultModelController` on `AddTask`, `AddSubTask` and `GetTasks` methods.

Each log contains `filename, method, timestamp, severity level`.