### PR TITLE
Fixed linux compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16)
 project(SimpleTaskManager)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/src/logs/DefaultLogging.h
+++ b/src/logs/DefaultLogging.h
@@ -9,9 +9,20 @@
 #include <boost/log/expressions/formatters/named_scope.hpp>
 #include <boost/log/utility/manipulators/add_value.hpp>
 
+#ifdef __FILE_NAME__
+
 #define LOG_TRIVIAL(LEVEL) \
     BOOST_LOG_TRIVIAL(LEVEL)   \
         << boost::log::add_value("File", __FILE_NAME__) \
         << boost::log::add_value("Function", __FUNCTION__)
+
+#else
+
+#define LOG_TRIVIAL(LEVEL) \
+    BOOST_LOG_TRIVIAL(LEVEL)   \
+        << boost::log::add_value("File", __FILE__) \
+        << boost::log::add_value("Function", __FUNCTION__)
+
+#endif
 
 #endif //SIMPLETASKMANAGER_DEFAULTLOGGING_H


### PR DESCRIPTION
- Fixed __FILE_NAME__ macros led to compilation fail on GNU
- Made CMake minimum version 3.16